### PR TITLE
Fix exports file

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+# Vagrant only
+# Can't run an NFS server inside Docker
+driver:
+  name: vagrant
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: nfs-share
+
+ansible:
+  diff: True
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,44 @@
+---
+- hosts: all
+
+  pre_tasks:
+
+    - name: Create unprivileged test user
+      user:
+        name: test
+        uid: 12345
+
+    - name: Create directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: test
+      with_items:
+        - /srv/ro
+        - /srv/rw
+        - /mnt/ro
+        - /mnt/rw
+
+  roles:
+
+    - role: ansible-role-nfs-share
+      nfs_shares:
+        /srv/ro:
+        - host: "*"
+          options: 'ro'
+        /srv/rw:
+        - host: "*"
+          options: 'rw'
+
+# Testing
+- hosts: all
+  roles:
+    - role: openmicroscopy.nfs-mount
+      nfs_share_mounts:
+      - path: /mnt/ro
+        location: localhost:/srv/ro
+        # Deliberately mount rw so we can check ro is enforced by server
+        opts: rw
+      - path: /mnt/rw
+        location: localhost:/srv/rw
+        opts: rw

--- a/templates/exports.j2
+++ b/templates/exports.j2
@@ -1,3 +1,4 @@
 {% for key, value in nfs_shares.iteritems() %}
-{{ key }} {% for access in value %} {{ access.host }}({{ access.options | default("ro,all_squash") }}) {% endfor %}
+{{ key }} {% for access in value %} {{ access.host }}({{ access.options | default("ro,all_squash") }}){% endfor %}
+
 {% endfor %}

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: openmicroscopy.nfs-mount

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,24 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_readonly(Command, File, Sudo):
+    f = '/mnt/ro/hello'
+    with Sudo('test'):
+        c = Command('touch %s', f)
+    assert c.rc == 1
+    assert not File(f).exists
+
+
+def test_readwrite(Command, File, Sudo):
+    f = '/mnt/rw/hello'
+    with Sudo('test'):
+        c1 = Command('touch %s', f)
+    assert c1.rc == 0
+    assert File(f).exists
+    with Sudo('test'):
+        c2 = Command('rm %s', f)
+    assert c2.rc == 0
+    assert not File(f).exists


### PR DESCRIPTION
Fixes a bug due to a missing newline when there are multiple exports.

Also adds a molecule test for vagrant only, since you can't run an NFS server in Docker (so the old .travis.yml is unchanged). Manually test using `molecule test`

Tag: `1.0.1`?